### PR TITLE
v2.2 changes

### DIFF
--- a/FileZapper.Core/Configuration/FileZapperSettings.cs
+++ b/FileZapper.Core/Configuration/FileZapperSettings.cs
@@ -24,6 +24,7 @@ namespace FileZapper.Core.Configuration
 {
     public class FileZapperSettings
     {
+        public bool DupeCheckIgnoresHierarchy { get; set; }
         public long IgnoreFilesBelowBytes { get; set; }
         public long IgnoreFilesOverBytes { get; set; }
         public string[] SkippedExtensions { get; set; }
@@ -46,6 +47,7 @@ namespace FileZapper.Core.Configuration
             {
                 throw new Exception("FileZapper config section missing");
             }
+            DupeCheckIgnoresHierarchy = _config.DupeCheckIgnoresHierarchy;
             IgnoreFilesBelowBytes = _config.IgnoreFilesBelowBytes;
             IgnoreFilesOverBytes = _config.IgnoreFilesOverBytes;
             SkippedExtensions = (_config.SkippedExtensions ?? "").Split(new char[] { ',' });

--- a/FileZapper.Core/Configuration/ZapperFolderConfigSection.cs
+++ b/FileZapper.Core/Configuration/ZapperFolderConfigSection.cs
@@ -1,6 +1,6 @@
 ﻿/*
     FileZapper - Finds and removed duplicate files
-    Copyright (C) 2014 Peter Wetzel
+    Copyright (C) 2016 Peter Wetzel
 
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
@@ -21,6 +21,9 @@ namespace FileZapper.Core.Configuration
 {
     public class ZapperFolderConfigSection : ConfigurationSection
     {
+        [ConfigurationProperty("DupeCheckIgnoresHierarchy", DefaultValue = "false")]
+        public bool DupeCheckIgnoresHierarchy { get { return (bool)this["DupeCheckIgnoresHierarchy"]; } }
+
         [ConfigurationProperty("IgnoreFilesBelowBytes", DefaultValue = "0")]
         public long IgnoreFilesBelowBytes { get { return (long)this["IgnoreFilesBelowBytes"]; } }
 

--- a/FileZapper.Core/Engine/PhaseCalculateHashes.cs
+++ b/FileZapper.Core/Engine/PhaseCalculateHashes.cs
@@ -47,6 +47,7 @@ namespace FileZapper.Core.Engine
             // TODO Test perf of parallelism here; since it's I/O bound, should we make it more aware of different disks being checked?
             var possibleDupes = 
                 (from z in ZapperProcessor.ZapperFiles.Values
+                where z.SampleHash != null
                 group z by new { z.Size, z.Extension, z.SampleHash } into g
                 select new { ContentHash = g.Key, Count = g.Count(), Files = g })
                 .Where(x => x.Count > 1);

--- a/FileZapper.Core/Engine/ZapperProcessor.cs
+++ b/FileZapper.Core/Engine/ZapperProcessor.cs
@@ -80,7 +80,7 @@ namespace FileZapper.Core.Engine
             try
             {
                 Console.ForegroundColor = ConsoleColor.White;
-                Console.WriteLine("FileZapper   Copyright (C) 2014 Peter Wetzel");
+                Console.WriteLine("FileZapper   Copyright (C) 2016 Peter Wetzel");
                 Console.WriteLine("This program comes with ABSOLUTELY NO WARRANTY; for details see license.txt.");
                 Console.ForegroundColor = ConsoleColor.Yellow;
                 Console.WriteLine("Current configuration settings...");

--- a/FileZapper.Core/FileZapper.Core.csproj
+++ b/FileZapper.Core/FileZapper.Core.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FileZapper.Core</RootNamespace>
     <AssemblyName>FileZapper.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -37,12 +37,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="CsvHelper, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8c4959082be5c823, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\CsvHelper.2.5.0\lib\net40-client\CsvHelper.dll</HintPath>
+      <HintPath>..\packages\CsvHelper.2.13.5.0\lib\net40-client\CsvHelper.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
@@ -83,7 +83,6 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/FileZapper.Core/Properties/AssemblyInfo.cs
+++ b/FileZapper.Core/Properties/AssemblyInfo.cs
@@ -4,13 +4,13 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("FileZapper.Core")]
 [assembly: AssemblyDescription("Finds and removes duplicate files from specified folders")]
 [assembly: AssemblyProduct("FileZapper")]
-[assembly: AssemblyCopyright("Copyright © 2014 Peter Wetzel")]
+[assembly: AssemblyCopyright("Copyright © 2016 Peter Wetzel")]
 [assembly: log4net.Config.XmlConfigurator(Watch = true)]
 [assembly: ComVisible(false)]
 [assembly: Guid("aff92b8c-1d0e-4df7-897e-6b5c2d92e69b")]
 
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
 /*
  * Version 2.1.0.0
  * - Added custom exceptions

--- a/FileZapper.Core/packages.config
+++ b/FileZapper.Core/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CsvHelper" version="2.5.0" targetFramework="net45" />
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="CsvHelper" version="2.13.5.0" targetFramework="net45" />
+  <package id="log4net" version="2.0.5" targetFramework="net45" />
 </packages>

--- a/FileZapper.Test/CalculateHashesTester.cs
+++ b/FileZapper.Test/CalculateHashesTester.cs
@@ -40,25 +40,25 @@ namespace FileZapper.Test
         }
 
         [Test]
-        public async void calculate_hash_single_file()
+        public void calculate_hash_single_file()
         {
             string sFilePath = Path.Combine(_rootFolder.FullPath, "alpha.txt");
-            string sHash = await PhaseCalculateHashes.CalculateMD5Hash(sFilePath);
-            Assert.IsNotNullOrEmpty(sHash);
+            string sHash = PhaseCalculateHashes.CalculateMD5Hash(sFilePath).Result;
+            Assert.That(sHash, Is.Not.Null.And.Not.Empty);
             System.Diagnostics.Trace.WriteLine("Hash for " + sFilePath + ": " + sHash);
         }
 
         [Test]
-        public async void calculate_hash_duplicate_files()
+        public void calculate_hash_duplicate_files()
         {
             string sFilePath = Path.Combine(_rootFolder.FullPath, "alpha.txt");
-            string sHashAlpha = await PhaseCalculateHashes.CalculateMD5Hash(sFilePath);
-            Assert.IsNotNullOrEmpty(sHashAlpha);
+            string sHashAlpha = PhaseCalculateHashes.CalculateMD5Hash(sFilePath).Result;
+            Assert.That(sHashAlpha, Is.Not.Null.And.Not.Empty);
             System.Diagnostics.Trace.WriteLine("Hash for " + sFilePath + ": " + sHashAlpha);
 
             sFilePath = Path.Combine(_rootFolder.FullPath, "bravo.txt");
-            string sHashBravo = await PhaseCalculateHashes.CalculateMD5Hash(sFilePath);
-            Assert.IsNotNullOrEmpty(sHashBravo);
+            string sHashBravo = PhaseCalculateHashes.CalculateMD5Hash(sFilePath).Result;
+            Assert.That(sHashBravo, Is.Not.Null.And.Not.Empty);
 
             Assert.AreEqual(sHashAlpha, sHashBravo);
         }

--- a/FileZapper.Test/FileZapper.Test.csproj
+++ b/FileZapper.Test/FileZapper.Test.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FileZapper.Test</RootNamespace>
     <AssemblyName>FileZapper.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,13 +31,13 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=2.6.3.13283, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.0\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>
@@ -74,10 +75,6 @@
     <ProjectReference Include="..\FileZapper.Core\FileZapper.Core.csproj">
       <Project>{d77746b1-e1d8-4028-afc2-d2dee4470e74}</Project>
       <Name>FileZapper.Core</Name>
-    </ProjectReference>
-    <ProjectReference Include="..\FileZapper\FileZapper.csproj">
-      <Project>{3c34b66f-a259-4bf7-9644-ec48ea997c67}</Project>
-      <Name>FileZapper</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/FileZapper.Test/Properties/AssemblyInfo.cs
+++ b/FileZapper.Test/Properties/AssemblyInfo.cs
@@ -4,13 +4,13 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("FileZapper.Test")]
 [assembly: AssemblyDescription("Finds and removes duplicate files from specified folders")]
 [assembly: AssemblyProduct("FileZapper")]
-[assembly: AssemblyCopyright("Copyright © 2014 Peter Wetzel")]
+[assembly: AssemblyCopyright("Copyright © 2016 Peter Wetzel")]
 
 [assembly: ComVisible(false)]
 [assembly: Guid("bad1b3f8-92b1-49c9-a5e8-cb20a15ef804")]
 
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
 /*
  * Version 2.1.0.0
  * - Added custom exceptions

--- a/FileZapper.Test/packages.config
+++ b/FileZapper.Test/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
-  <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="log4net" version="2.0.5" targetFramework="net45" />
+  <package id="NUnit" version="3.2.0" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
 </packages>

--- a/FileZapper/App.config
+++ b/FileZapper/App.config
@@ -5,14 +5,9 @@
     <section name="log4net" type="log4net.Config.Log4NetConfigurationSectionHandler, log4net"/>
   </configSections>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/>
   </startup>
-  <FileZapper
-    IgnoreFilesBelowBytes="0"
-    IgnoreFilesOverBytes="0"
-    SkippedExtensions=".zip,.rar"
-    UnwantedExtensions=".htm,.html"
-    UnwantedFolders="__MACOSX">
+  <FileZapper IgnoreFilesBelowBytes="0" IgnoreFilesOverBytes="0" SkippedExtensions=".zip,.rar" UnwantedExtensions=".htm,.html" UnwantedFolders="__MACOSX">
     <ZapperFolders>
       <add fullpath="I:\test" priority="300000"/>
       <add fullpath="I:\test2" priority="100000"/>
@@ -20,16 +15,16 @@
   </FileZapper>
   <log4net>
     <appender name="FileAppender" type="log4net.Appender.FileAppender">
-      <file value="log-file.txt" />
-      <appendToFile value="true" />
-      <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
+      <file value="log-file.txt"/>
+      <appendToFile value="true"/>
+      <lockingModel type="log4net.Appender.FileAppender+MinimalLock"/>
       <layout type="log4net.Layout.PatternLayout">
-        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline" />
+        <conversionPattern value="%date [%thread] %-5level %logger [%property{NDC}] - %message%newline"/>
       </layout>
     </appender>
     <root>
-      <level value="ALL" />
-      <appender-ref ref="FileAppender" />
+      <level value="ALL"/>
+      <appender-ref ref="FileAppender"/>
     </root>
   </log4net>
 </configuration>

--- a/FileZapper/FileZapper.csproj
+++ b/FileZapper/FileZapper.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -10,10 +10,25 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FileZapper</RootNamespace>
     <AssemblyName>FileZapper</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile>
     </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
+    <PublishUrl>publish\</PublishUrl>
+    <Install>true</Install>
+    <InstallFrom>Disk</InstallFrom>
+    <UpdateEnabled>false</UpdateEnabled>
+    <UpdateMode>Foreground</UpdateMode>
+    <UpdateInterval>7</UpdateInterval>
+    <UpdateIntervalUnits>Days</UpdateIntervalUnits>
+    <UpdatePeriodically>false</UpdatePeriodically>
+    <UpdateRequired>false</UpdateRequired>
+    <MapFileExtensions>true</MapFileExtensions>
+    <ApplicationRevision>0</ApplicationRevision>
+    <ApplicationVersion>1.0.0.%2a</ApplicationVersion>
+    <IsWebBootstrapper>false</IsWebBootstrapper>
+    <UseApplicationTrust>false</UseApplicationTrust>
+    <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -70,9 +85,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="log4net, Version=1.2.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\log4net.2.0.3\lib\net40-full\log4net.dll</HintPath>
+    <Reference Include="log4net, Version=1.2.15.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.5\lib\net45-full\log4net.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="System" />
@@ -100,6 +115,18 @@
       <Project>{d77746b1-e1d8-4028-afc2-d2dee4470e74}</Project>
       <Name>FileZapper.Core</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <BootstrapperPackage Include=".NETFramework,Version=v4.5">
+      <Visible>False</Visible>
+      <ProductName>Microsoft .NET Framework 4.5 %28x86 and x64%29</ProductName>
+      <Install>true</Install>
+    </BootstrapperPackage>
+    <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">
+      <Visible>False</Visible>
+      <ProductName>.NET Framework 3.5 SP1</ProductName>
+      <Install>false</Install>
+    </BootstrapperPackage>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/FileZapper/Properties/AssemblyInfo.cs
+++ b/FileZapper/Properties/AssemblyInfo.cs
@@ -3,11 +3,11 @@
 [assembly: AssemblyTitle("FileZapper")]
 [assembly: AssemblyDescription("Finds and removes duplicate files from specified folders")]
 [assembly: AssemblyProduct("FileZapper")]
-[assembly: AssemblyCopyright("Copyright © 2014 Peter Wetzel")]
+[assembly: AssemblyCopyright("Copyright © 2016 Peter Wetzel")]
 [assembly: log4net.Config.XmlConfigurator(Watch = true)]
 
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]
 /*
  * Version 2.1.0.0
  * - Added custom exceptions

--- a/FileZapper/packages.config
+++ b/FileZapper/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="log4net" version="2.0.3" targetFramework="net45" />
+  <package id="log4net" version="2.0.5" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
- Added new boolean setting "DupeCheckIgnoresHierarchy" to help speed up process; now by default will only sample hashes from same folder.
- Bug fix: full hashing algorithm now properly skips files with no sample
hash
- Now targets .NET framework v4.6.1 (was v4.5)
- Nuget update
- Updated tests to be compatible with v3 of NUnit
- Added and refined tests